### PR TITLE
Laravel mix 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "laravel-mix-brotli",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "A wrapper around brotli-webpack-plugin for Laravel Mix",
     "main": "index.js",
     "repository": {
@@ -23,7 +23,7 @@
     },
     "devDependencies": {},
     "peerDependencies": {
-        "laravel-mix": "^4.0.0"
+        "laravel-mix": "^6.0.0"
     },
     "engines": {
         "node": ">=6.0.0"


### PR DESCRIPTION
Installing this package with Laravel Mix 6 will give an error while resolving the dependency tree. Updating the requirement in package.json fixes this error.